### PR TITLE
Contract test work anniversary

### DIFF
--- a/tests/test_contract_work_service.py
+++ b/tests/test_contract_work_service.py
@@ -1,0 +1,43 @@
+import os
+import json
+import atexit
+import unittest
+import pytest
+import requests
+import logging
+from pact import Consumer, Provider, Format
+
+
+# Declaring logger
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+print(Format().__dict__)
+
+#Declaring PACT directory
+REPO_DIR = os.path.dirname(os.path.dirname(__file__))
+PACT_DIR = os.path.join(REPO_DIR,'tests')
+
+pact = Consumer('Qxf2 Employee Service').has_pact_with(Provider('Qxf2 daily messages microservices'),pact_dir=PACT_DIR, log_dir=PACT_DIR)
+pact.start_service()
+atexit.register(pact.stop_service)
+
+class Workanniversary(unittest.TestCase):
+    "Contract test"
+    def check_employee_data_return(self):
+        "check it's returning the correct employee data"
+        expected = {
+        'msg' : '{"errors":[{"message":"Must provide query string."}]}'
+        }
+
+        (pact\
+        . given('Request to get home page') \
+        . upon_receiving('a request for home page')\
+        . with_request('GET', '/')\
+        . will_respond_with(200, body=expected))\
+
+        with pact:\
+            result = requests.get(pact.uri + '/')\
+
+        self.assertEqual(result.json(), expected)
+        pact.verify()
+

--- a/tests/test_contract_work_service.py
+++ b/tests/test_contract_work_service.py
@@ -1,3 +1,5 @@
+"Contract test for work anniversary"
+
 import os
 import json
 import atexit

--- a/tests/test_contract_work_service.py
+++ b/tests/test_contract_work_service.py
@@ -9,7 +9,6 @@ import requests
 import logging
 from pact import Consumer, Provider, Format
 
-
 # Declaring logger
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -19,26 +18,28 @@ print(Format().__dict__)
 REPO_DIR = os.path.dirname(os.path.dirname(__file__))
 PACT_DIR = os.path.join(REPO_DIR,'tests')
 
-pact = Consumer('Qxf2 Employee Service').has_pact_with(Provider('Qxf2 daily messages microservices'),pact_dir=PACT_DIR, log_dir=PACT_DIR)
+
+# Setting up pact
+pact = Consumer('Consumer').has_pact_with(Provider('Provider'))
 pact.start_service()
 atexit.register(pact.stop_service)
 
+print(pact)
 class Workanniversary(unittest.TestCase):
     "Contract test"
-    def check_employee_data_return(self):
+    def test_check_employee_data_return(self):
         "check it's returning the correct employee data"
         expected = {
         'msg' : '{"errors":[{"message":"Must provide query string."}]}'
         }
-
         (pact\
         . given('Request to get home page') \
         . upon_receiving('a request for home page')\
-        . with_request('GET', '/')\
+        . with_request('GET', '/qxf2-employees.qxf2.com/graphql')\
         . will_respond_with(200, body=expected))\
 
         with pact:\
-            result = requests.get(pact.uri + '/')\
+            result = requests.get(pact.uri + '/qxf2-employees.qxf2.com/graphql')\
 
         self.assertEqual(result.json(), expected)
         pact.verify()

--- a/work-anniversary/requirements.txt
+++ b/work-anniversary/requirements.txt
@@ -2,3 +2,4 @@ requests==2.25.0
 python-dateutil==2.8.1
 Pillow==7.2.0
 inflect==5.0.2
+pact-python==1.3.5


### PR DESCRIPTION
Added the contract tests for https://qxf2-employees.qxf2.com/graphql for this url.

To get the employee data we have to use the query and mock it. I will try this in sepaarate branch

As of now I am checking whether its returning the correct error message or not. It should show the employee data without username and password.

So we are getting the actual and expected output.

Files added are
-tests/test_contract_work_service.py

Changed file:
work-anniversary/requirements.txt

To run the file
pytest tests/test_contract_work_service.py

It creates consumer-provider.json file and the test will be passed