### PR TITLE
Fixed problem of sending channel ids with uppercase letters

### DIFF
--- a/skype_sender/qxf2_skype_sender.py
+++ b/skype_sender/qxf2_skype_sender.py
@@ -16,7 +16,9 @@ def get_dict(my_string):
 
 def get_channel_id(msg_body):
     "Return the channel id, default to main if channel not available"
-    channel = msg_body.get('channel','main').lower()
+    channel = msg_body.get('channel','main')
+    if channel[-6:].lower() == '.skype':
+        channel = channel.lower()
     channels = get_dict(os.environ.get('SKYPE_CHANNELS'))
     channel_id = channels.get(channel,channel)
 


### PR DESCRIPTION
The current Skype sender will not work when you send it a channel id that has upper case letters. I discovered this while developing the `code reviewer` lambda. The fix is to convert the channel to lower case only if it is not a channel id ending in `.skype`. We still need to convert to lowercase when channel ids are sent as human friendly strings.