### PR TITLE
Fixed trailing hyphen in URL patterns

### DIFF
--- a/url_filtering_lambda_rohini/url_filtering_lambda_rohini.py
+++ b/url_filtering_lambda_rohini/url_filtering_lambda_rohini.py
@@ -27,7 +27,8 @@ def get_url(message):
     "Get the URL from the message"
     regex = r"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'\".,<>?«»“”‘’]))"
     url = re.findall(regex,message)
-    return [x[0] for x in url]
+
+    return [x[0] for x in url if x[-1]!='-']
 
 def post_to_newsletter(final_url, category_id = '2'):
     "Method to call the newsletter API and post the url"


### PR DESCRIPTION
There was a bug that we found testing on prod. The URL parser is identifying `url` and `url-` in a string. I modified the lambda to ignore the last `-`.