### PR TITLE
Make chatgpt optional in the URL filter lambda

### DIFF
--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -5,7 +5,7 @@ version: '3.8'
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack:latest
+    image: localstack/localstack:2.2
     ports:
       - "4566:4566"            # LocalStack Gateway
       - "4510-4559:4510-4559"  # external services port range

--- a/url_filtering_lambda_rohini/url_filtering_lambda_rohini.py
+++ b/url_filtering_lambda_rohini/url_filtering_lambda_rohini.py
@@ -44,7 +44,7 @@ def process_reply(reply):
 
 def ask_the_all_knowing_one(input_message, max_tokens=512):
     "Return the ChatGPT response"
-    openai.api_key = 'ak-1viMSg3Mtk2vK76WQMEiT3BlbkFJFo4njQoZ3oLcnnhTlL6v'
+    openai.api_key = os.environ.get('CHATGPT_API_KEY', '')
     model_engine = os.environ.get('CHATGPT_VERSION', 'gpt-3.5-turbo')
     summary_and_title = ''
     input_message = "I want you to format your reply in a specific manner to this request." \

--- a/url_filtering_lambda_rohini/url_filtering_lambda_rohini.py
+++ b/url_filtering_lambda_rohini/url_filtering_lambda_rohini.py
@@ -44,9 +44,9 @@ def process_reply(reply):
 
 def ask_the_all_knowing_one(input_message, max_tokens=512):
     "Return the ChatGPT response"
-    openai.api_key = os.environ.get('CHATGPT_API_KEY', '')
+    openai.api_key = 'ak-1viMSg3Mtk2vK76WQMEiT3BlbkFJFo4njQoZ3oLcnnhTlL6v'
     model_engine = os.environ.get('CHATGPT_VERSION', 'gpt-3.5-turbo')
-
+    summary_and_title = ''
     input_message = "I want you to format your reply in a specific manner to this request." \
                     "I am going to send you an article (in quotes at the end of this message)." \
                     "You tell me its title and summary." \
@@ -55,15 +55,23 @@ def ask_the_all_knowing_one(input_message, max_tokens=512):
                     "and preface the summary with the exact string SUMMARY:" \
                     "If you do not know, then put TITLE: UNKNOWN and SUMMARY: UNKNOWN." \
                     f"Ok, here is the article '{input_message}'"
+    try:
+        if openai.api_key.strip():
+            response = openai.ChatCompletion.create(
+                    model=model_engine,
+                    messages=[
+                        {"role": "user", "content": input_message},
+                    ],
+                    max_tokens=max_tokens
+                )
+            summary_and_title = response["choices"][0]["message"]["content"]
+        else:
+            print('ChatGPT skipped since no key is setup.')
+    except Exception as e:
+        print('Unable to make call to ChatGPT.')
+        print(f'Python says: {e}')
 
-    response = openai.ChatCompletion.create(
-            model=model_engine,
-            messages=[
-                {"role": "user", "content": input_message},
-            ],
-            max_tokens=max_tokens
-        )
-    return response["choices"][0]["message"]["content"]
+    return summary_and_title
 
 def get_title_summary(article_url):
     "Ask ChatGPT for the title and summary"


### PR DESCRIPTION
Prep work before open sourcing our terraform code. Not everyone will have a chatgpt key. So made it optional.

Note: Our tests were stale compared to the latest localstack. I had to fix the localstack docker image and the tests passed.