### PR TITLE
Fixed environment name typo in url filter's workflow file

### DIFF
--- a/.github/workflows/url_filtering_lambda_rohini.yml
+++ b/.github/workflows/url_filtering_lambda_rohini.yml
@@ -78,7 +78,7 @@ jobs:
     needs: test-lambda
     if: github.event.ref == 'refs/heads/master'
     environment:
-      name: production-url-filter
+      name: production
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
Somehow we seem to have never tested a deploy of the lambda to production using the workflow file. ¯\_(ツ)_/¯